### PR TITLE
Jobrandt/xcode4 2 1

### DIFF
--- a/src/mac/include/internal/cef_build.h
+++ b/src/mac/include/internal/cef_build.h
@@ -68,8 +68,8 @@
 //   virtual void foo() OVERRIDE;
 #if defined(COMPILER_MSVC)
 #define OVERRIDE override
-#elif defined(__clang__)
-#define OVERRIDE
+//#elif defined(__clang__)
+//#define OVERRIDE override
 #else
 #define OVERRIDE
 #endif


### PR DESCRIPTION
This minor change fixes up the OVERRIDE define so that it works with the version of clang in Xcode 4.2.1
