### PR TITLE
change icon file names in win project

### DIFF
--- a/src/win/cefclient.vcxproj
+++ b/src/win/cefclient.vcxproj
@@ -262,7 +262,8 @@
     <None Include="cefclient.gyp" />
     <None Include="cefclient\res\brackets_extensions.js" />
     <None Include="cefclient\res\extensionperf.html" />
-    <None Include="cefclient\res\cefclient.ico" />
+    <None Include="cefclient\res\brackets.ico" />
+    <None Include="cefclient\res\brackets_small.ico" />
     <None Include="cefclient\res\osrplugin.html" />
     <None Include="cefclient\res\domaccess.html" />
     <None Include="cefclient\res\transparency.html" />
@@ -270,7 +271,6 @@
     <None Include="cefclient\res\modaldialog.html" />
     <None Include="cefclient\res\localstorage.html" />
     <None Include="cefclient\res\xmlhttprequest.html" />
-    <None Include="cefclient\res\small.ico" />
     <None Include="cefclient\res\logo.png" />
     <None Include="cefclient\res\logoball.png" />
     <None Include="cefclient\res\uiplugin.html" />

--- a/src/win/cefclient.vcxproj.filters
+++ b/src/win/cefclient.vcxproj.filters
@@ -199,7 +199,10 @@
     <None Include="cefclient\res\extensionperf.html">
       <Filter>cefclient\res</Filter>
     </None>
-    <None Include="cefclient\res\cefclient.ico">
+    <None Include="cefclient\res\brackets.ico">
+      <Filter>cefclient\res</Filter>
+    </None>
+    <None Include="cefclient\res\brackets_small.ico">
       <Filter>cefclient\res</Filter>
     </None>
     <None Include="cefclient\res\osrplugin.html">
@@ -221,9 +224,6 @@
       <Filter>cefclient\res</Filter>
     </None>
     <None Include="cefclient\res\xmlhttprequest.html">
-      <Filter>cefclient\res</Filter>
-    </None>
-    <None Include="cefclient\res\small.ico">
       <Filter>cefclient\res</Filter>
     </None>
     <None Include="cefclient\res\logo.png">


### PR DESCRIPTION
This change should have been done when I updated the icons last week. It is to show the correct files in the Visual Studio project. It does not affect the build, so Brackets.exe was not updated.
