### PR TITLE
Do not use a Class Extension to declare private methods of a category

### DIFF
--- a/src/mac/cefclient/NSAlert+SynchronousSheet.m
+++ b/src/mac/cefclient/NSAlert+SynchronousSheet.m
@@ -9,7 +9,7 @@
 
 
 // Private methods -- use prefixes to avoid collisions with Apple's methods
-@interface NSAlert ()
+@interface NSAlert (SynchronousSheetPrivate)
 -(IBAction) BE_stopSynchronousSheet:(id)sender;   // hide sheet & stop modal
 -(void) BE_beginSheetModalForWindow:(NSWindow *)aWindow;
 @end


### PR DESCRIPTION
I ran across this bug when trying to compile Brackets-app in the latest version of Xcode (4.3)

src/mac/cefclient/NSAlert+SynchronousSheet.m throws a compile error in Xcode 4.3:
Category is implementing a method which will also be implemented by its primary class

Fix: use an undefined category name to declare private methods (I used "SynchronousSheetPrivate")
You cannot use the same as in the header, because that will also throw a compile error.

An alternative would be to also implement the private category using @implement (SynchronousSheetPrivate) and move the private methods there. The only benefit of doing that is to get compile errors if methods from the interface are not implemented. I have not done this as the change would be more invasive.
